### PR TITLE
fix: URL-decode query parameters in HTTP route handler

### DIFF
--- a/cpp/src/server.cpp
+++ b/cpp/src/server.cpp
@@ -131,6 +131,38 @@ public:
 };
 
 // ---------------------------------------------------------------------------
+// URL decode utility (fix P0: raw %XX and + in query params were passed through)
+// ---------------------------------------------------------------------------
+static int from_hex(char ch) {
+    if (ch >= '0' && ch <= '9') return ch - '0';
+    if (ch >= 'a' && ch <= 'f') return ch - 'a' + 10;
+    if (ch >= 'A' && ch <= 'F') return ch - 'A' + 10;
+    return -1;
+}
+
+static std::string url_decode(const std::string& str) {
+    std::string result;
+    result.reserve(str.size());
+    for (size_t i = 0; i < str.size(); ++i) {
+        if (str[i] == '%' && i + 2 < str.size()) {
+            int hi = from_hex(str[i + 1]);
+            int lo = from_hex(str[i + 2]);
+            if (hi >= 0 && lo >= 0) {
+                result += static_cast<char>((hi << 4) | lo);
+                i += 2;
+            } else {
+                result += str[i];
+            }
+        } else if (str[i] == '+') {
+            result += ' ';
+        } else {
+            result += str[i];
+        }
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
 // Server 实现
 // ---------------------------------------------------------------------------
 class StockDbServerImpl {
@@ -267,10 +299,10 @@ private:
         }
 
         const std::string& cmd = params["cmd"];
-        if (cmd == "get")    return process_cmd_get(params["t"]);
-        if (cmd == "set")    return process_cmd_set(params["key"], params["val"]);
-        if (cmd == "zb.get") return process_zb_get(params["name"], params["codes"], params["start"], params["end"]);
-        if (cmd == "bk.get") return process_bk_get(params["x"], params["category"]);
+        if (cmd == "get")    return process_cmd_get(url_decode(params["t"]));
+        if (cmd == "set")    return process_cmd_set(url_decode(params["key"]), url_decode(params["val"]));
+        if (cmd == "zb.get") return process_zb_get(url_decode(params["name"]), url_decode(params["codes"]), url_decode(params["start"]), url_decode(params["end"]));
+        if (cmd == "bk.get") return process_bk_get(url_decode(params["x"]), url_decode(params["category"]));
 
         return "{\"status\":\"ok\",\"engine\":\"StockDB/LevelDB\"}";
     }


### PR DESCRIPTION
## Problem

`route()` passes raw `%XX`-encoded query string values directly to LevelDB without decoding. This breaks all non-ASCII keys and JSON values:

```bash
# Before (broken): Chinese key stored/retrieved as mojibake
curl "http://127.0.0.1:7899/?cmd=set&key=%E6%9D%BF%E5%9D%97%3A%E7%99%BD%E9%85%92&val=%7B%22name%22%3A%22%E7%99%BD%E9%85%92%22%7D"
curl "http://127.0.0.1:7899/?cmd=bk.get&x=%E7%99%BD%E9%85%92"
# Returns: %7B%22name%22%3A%22%E7%99%BD%E9%85%92%22%7D  ← raw encoded, unusable
```

## Fix

Added `url_decode()` that handles `%XX` hex decoding (multi-byte UTF-8 safe) and `+` → space conversion. Applied to all `cmd` parameters: `get`, `set`, `zb.get`, `bk.get`.

```bash
# After (fixed): Chinese key correctly decoded
curl "http://127.0.0.1:7899/?cmd=bk.get&x=%E7%99%BD%E9%85%92"
# Returns: {"name":"白酒","codes":["600519","000568"]}  ← correct JSON
```

## Verification

Tested on macOS (arm64, Apple Clang 21, LevelDB 1.23, OpenSSL 3.6.3):

| Test | Before | After |
|---|---|---|
| `bk.get` with Chinese key (`白酒`) | `%7B%22name%22...` (broken) | `{"name":"白酒",...}` ✅ |
| `set` with JSON value | Stored as mojibake | Correctly decoded ✅ |
| `get` with Chinese key (`日k:600519:*`) | Broken wildcard | Correct prefix scan ✅ |
| Existing ASCII functionality | Works | Unchanged ✅ |

## Changes

```
cpp/src/server.cpp | 40 ++++++++++++++++++++++++++++++++++++----
1 file changed, 36 insertions(+), 4 deletions(-)
```

Single file, no API changes, no new dependencies. Independent of #44 (concurrency fix).