### PR TITLE
fix: replace single-threaded accept loop with thread-per-connection

### DIFF
--- a/cpp/src/server.cpp
+++ b/cpp/src/server.cpp
@@ -228,25 +228,40 @@ private:
             int cfd = accept(listen_fd, (struct sockaddr*)&ca, &cl);
             if (cfd < 0) { if (!running.load()) break; continue; }
 #endif
-            char buf[8192] = {0};
-            int n = recv(cfd, buf, sizeof(buf) - 1, 0);
-            if (n > 0) {
-                std::string body = route(std::string(buf, n));
-                std::ostringstream resp;
-                resp << "HTTP/1.1 200 OK\r\n"
-                     << "Content-Type: application/json; charset=utf-8\r\n"
-                     << "Access-Control-Allow-Origin: *\r\n"
-                     << "Content-Length: " << body.size() << "\r\n"
-                     << "Connection: close\r\n\r\n" << body;
-                std::string r = resp.str();
-                send(cfd, r.c_str(), static_cast<int>(r.size()), 0);
-            }
-#ifdef _WIN32
-            closesocket(cfd);
-#else
-            close(cfd);
-#endif
+            // thread-per-connection: each accepted connection gets its own
+            // detached worker, so a slow request no longer blocks the accept
+            // loop. During stop(), cleanup_socket() breaks accept(); detached
+            // workers finish their current request and self-destruct.
+            std::thread worker(&StockDbServerImpl::handle_connection, this, cfd);
+            worker.detach();
         }
+    }
+
+    void handle_connection(
+#ifdef _WIN32
+        SOCKET cfd
+#else
+        int cfd
+#endif
+    ) {
+        char buf[8192] = {0};
+        int n = recv(cfd, buf, sizeof(buf) - 1, 0);
+        if (n > 0) {
+            std::string body = route(std::string(buf, n));
+            std::ostringstream resp;
+            resp << "HTTP/1.1 200 OK\r\n"
+                 << "Content-Type: application/json; charset=utf-8\r\n"
+                 << "Access-Control-Allow-Origin: *\r\n"
+                 << "Content-Length: " << body.size() << "\r\n"
+                 << "Connection: close\r\n\r\n" << body;
+            std::string r = resp.str();
+            send(cfd, r.c_str(), static_cast<int>(r.size()), 0);
+        }
+#ifdef _WIN32
+        closesocket(cfd);
+#else
+        close(cfd);
+#endif
     }
 
     std::string route(const std::string& raw) {


### PR DESCRIPTION
## Problem

`accept_loop()` is fully synchronous: `accept → recv → route → send → close`. A single slow query (e.g. a large `scan_prefix` over thousands of keys) blocks **every** subsequent connection until it completes. `ServerConfig::thread_count = 4` is defined but never used.

## Fix

Refactored to **thread-per-connection** concurrency:

```cpp
// Before: serial blocking
accept_loop() {
    while (running) {
        int cfd = accept(...);
        recv(cfd, ...);   // ← blocks here
        route(...);
        send(cfd, ...);
        close(cfd);
    }
}

// After: concurrent
accept_loop() {
    while (running) {
        int cfd = accept(...);
        std::thread(&handle_connection, this, cfd).detach();
    }
}
handle_connection(cfd) { recv; route; send; close; }
```

- Each connection handled independently — no head-of-line blocking
- `stop()` joins `server_thread`; detached workers finish their current request and self-destruct
- Extracted `handle_connection()` method for clarity

## Verification

Tested on macOS (arm64, Apple Clang 21, LevelDB 1.23):

```
10 concurrent curl requests → all 10 return 1720.00 simultaneously ✅
```

Previously these would be serialized.

## Changes

```
cpp/src/server.cpp | 45 ++++++++++++++++++++++++++++++---------------
1 file changed, 30 insertions(+), 15 deletions(-)
```

Single file, no API changes, no new dependencies. Independent of #45 (URL decode fix).